### PR TITLE
Update freefilesync to use Github

### DIFF
--- a/Casks/freefilesync.rb
+++ b/Casks/freefilesync.rb
@@ -1,10 +1,10 @@
 cask 'freefilesync' do
-  version '12.2'
+  version '12.3'
   sha256 :no_check
 
-  url "https://freefilesync.org/download/FreeFileSync_#{version}_macOS.zip"
+  url "https://github.com/hkneptune/FreeFileSync/releases/download/v12.3/FreeFileSync_#{version}_macOS.zip"
   name 'freefilesync'
-  homepage 'https://freefilesync.org/download.php'
+  homepage 'https://github.com/hkneptune/FreeFileSync/releases'
 
   auto_updates true
 

--- a/Casks/freefilesync.rb
+++ b/Casks/freefilesync.rb
@@ -2,7 +2,7 @@ cask 'freefilesync' do
   version '12.3'
   sha256 :no_check
 
-  url "https://github.com/hkneptune/FreeFileSync/releases/download/v12.3/FreeFileSync_#{version}_macOS.zip"
+  url "https://github.com/hkneptune/FreeFileSync/releases/download/v#{version}/FreeFileSync_#{version}_macOS.zip"
   name 'freefilesync'
   homepage 'https://github.com/hkneptune/FreeFileSync/releases'
 


### PR DESCRIPTION
I'm not sure why in forums the discussion for  the brew casks always point to freefilesync website, when they publish their releases on GitHub, which i would assume to be a more reliable download link.